### PR TITLE
Remove unecessary import of numpy

### DIFF
--- a/pynsee/utils/_get_credentials.py
+++ b/pynsee/utils/_get_credentials.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import os
 import pandas as pd
 from functools import lru_cache
-import numpy as np
 
 
 def _get_credentials():


### PR DESCRIPTION
Just been using your patch about corporate proxy (working fine here on py3.9).
I just fixed the unnecessary import of numpy (which stayed in your patch).

`Note : this is my first pull request inside an inpending pull request ; not a git expert here, I hope I'm not doing anything wrong...`